### PR TITLE
Downsampling Plugin for Flot

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -132,6 +132,10 @@ Draws multiple axes through the plot's origin.</p>
 <em>by <a href="https://github.com/jumjum123">Jürgen Marsch</a></em> -
 Enables basic (min, max, average) and user-defined aggregation functions.</p>
 
+<p><a href="https://github.com/sveinn-steinarsson/flot-downsample/">Downsample</a>
+<em>by <a href="https://github.com/sveinn-steinarsson">Sveinn Steinarsson</a></em> -
+Retains the visual characteristics of the original line chart using considerably fewer data points.</p>
+
 <p><a href="https://github.com/markrcote/flot-hiddengraphs">Hidden Graphics</a>
 <em>by <a href="https://github.com/markrcote">Mark Côté</a></em> -
 Toggles visibility of individual series.</p>


### PR DESCRIPTION
I have been researching various methods to downsample line charts (trying to retain the visual characteristics). I wanted to publish one of the more efficient algorithms called Largest-Triangle-Three-Buckets. It is derived from one method of polyline simplification used in cartographic generalization, adapted to be used on line charts and optimized for JavaScript.

Live demo can viewed at [flot.base.is](http://flot.base.is/)

Regards,
Sveinn Steinarsson
Iceland
