### PR TITLE
Add a plug in to allow users save the current chart as an image file.

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -144,6 +144,11 @@ Toggles visibility of individual series.</p>
 <em>by <a href="https://github.com/troelsjensen">Troels Bang Jensen</a> of <a href="https://github.com/Uni-tel">Uni-tel</a></em> -
 Automates creation of a 'mini-map' plot used to navigate within the main plot.</p>
 
+<p><a href="https://github.com/Jeff-Tian/jquery.flot.saveAsImage.js">Save as Image</a>
+<em>by <a href="https://github.com/Jeff-Tian">Jeff Tian</a></em> -
+Allows user to save the current chart as an image file in png/bmp/jpeg format into local disk by 
+mouse right clicking on the chart and then choose "Save image as ..." option.</p>
+
 <p><a href="http://justindarc.github.com/flot.touch">Touch</a>
 <em>by <a href="https://github.com/justindarc">Justin D'Arcangelo</a></em> -
 Adds multi-touch gesture support for panning and zooming.</p>


### PR DESCRIPTION
Allow users save the current chart as an image file to local disk. 
Screen shot here: http://zizhujy.com/blog/post/2013/07/02/A-Flot-plugin-for-saving-canvas-image-to-local-disk.aspx
