### PR TITLE
Adds navigation control buttons on top of the canvas layer to allow touch screen users to pan or zoom the chart.

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -136,6 +136,10 @@ Enables basic (min, max, average) and user-defined aggregation functions.</p>
 <em>by <a href="https://github.com/sveinn-steinarsson">Sveinn Steinarsson</a></em> -
 Retains the visual characteristics of the original line chart using considerably fewer data points.</p>
 
+<p><a href="https://github.com/Jeff-Tian/jquery.flot.navigationControl">Navigation Control</a>
+<em>by <a href="https://github.com/Jeff-Tian">Jeff Tian</a></em> - 
+Adds navigation control buttons on top of the canvas layer to allow touch screen users to pan or zoom the chart.</p>
+
 <p><a href="https://github.com/markrcote/flot-hiddengraphs">Hidden Graphics</a>
 <em>by <a href="https://github.com/markrcote">Mark Côté</a></em> -
 Toggles visibility of individual series.</p>


### PR DESCRIPTION
Flot plugin that adds some navigation controls on top of the canvas layer to allow users pan or zoom the graph. This is even more helpful for the touch screen users.
![screenshot](https://f.cloud.github.com/assets/3367820/846672/2d0605d0-f41e-11e2-80ea-e8d9fb6c92d1.png)
