### PR TITLE
Fix broken plugin link & add attribution link to match other entries

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -26,9 +26,9 @@ Gives Flot the ability to create bubble (scatter-size) plots.</p>
 <em>by <a href="https://github.com/jumjum123">Jürgen Marsch</a></em> -
 Gives Flot the ability to create candlestick (open-high-low-close) charts.</p>
 
-<p><a href="http://www.billigerbiken.de/CurvedLines">Curved Lines</a>
+<p><a href="http://curvedlines.michaelzinsmaier.de/">Curved Lines</a>
 (<a href="https://github.com/MichaelZinsmaier/CurvedLines">GitHub</a>)
-<em>by Michael Zinsmaier, based on work by nergal.dev</em> -
+<em>by <a href="https://github.com/MichaelZinsmaier">Michael Zinsmaier</a>, based on work by nergal.dev</em> -
 Allows line plots to produce smooth curves.</p>
 
 <p><a href="http://code.google.com/p/jquery-flot-direction/">Direction</a>


### PR DESCRIPTION
I just noticed this plugin link was broken, so I have updated the entry accordingly.
