### PR TITLE
Fill below plugin

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -62,6 +62,10 @@ Gives Flot the ability to draw spider (radar/web) plots.</p>
 <em>by <a href="https://github.com/kcdr">kcdr</a></em> -
 Draws markers for minimum/maximum range and average values of series.</p>
 
+<p><a href="https://github.com/whatbox/jquery.flot.fillbelow">Fill Below</a>
+<em>by <a href="https://github.com/anthonyryan1">anthonyryan1</a></em> -
+Fill below instead of between, useful for difference line graphs.</p>
+
 <p><a href="https://github.com/analoureiro99/flot-fillArea-plugin">Fill Between</a>
 <em>by <a href="https://github.com/analoureiro99">analoureiro99</a></em> -
 An alternative to the core fill-between plugin.</p>


### PR DESCRIPTION
A link to a fill below plugin that behaves differently than fillbetween and allows the creation of difference line graphs.
