### PR TITLE
Update site to display latest NPM version

### DIFF
--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -8,7 +8,9 @@
 			<div class="downloads-area">
 				<a href="https://www.npmjs.com/package/flot" class="download-entry">
 					<div class="flot-icon flot-icon-80 npm-icon"></div>
-					<div class="download-caption">Version <span class="download-version">2.1.6</span></div>
+					<div class="download-caption">
+						<img src="https://img.shields.io/npm/v/flot?color=%23cb3837&label=version">
+					</div>
 				</a>
 				<a href="https://github.com/flot/flot" class="download-entry">
 					<div class="flot-icon flot-icon-80 github-icon"></div>


### PR DESCRIPTION
This swaps out the static version displayed on the site for a dynamic image coming from https://shields.io/. 
![image](https://user-images.githubusercontent.com/9257800/63529204-ee7ab300-c4c9-11e9-901e-432e86bd3f18.png)
This badge is a really common pattern you see in a lot of GitHub repos. I also updated the flot submodule to the latest on master.